### PR TITLE
Update the default data generation (Fixtures)

### DIFF
--- a/src/Factory/BoardFactory.php
+++ b/src/Factory/BoardFactory.php
@@ -28,10 +28,10 @@ final class BoardFactory extends PersistentProxyObjectFactory
      *
      * @todo add your default values here
      */
-    protected function defaults(): array|callable
+    protected function defaults(): array
     {
         return [
-            'title' => fn() => self::faker()->randomElement([
+            'title' => self::faker()->randomElement([
                 'Website Redesign Project',
                 'Mobile App Development',
                 'Marketing Campaign Q4',
@@ -46,7 +46,7 @@ final class BoardFactory extends PersistentProxyObjectFactory
                 'Client Projects',
                 'Personal Tasks',
                 'Team Meeting Notes',
-                'Infrastructure Migration'
+                'Infrastructure Migration',
             ]),
             'owner' => AccountFactory::new(),
         ];

--- a/src/Factory/BoardFactory.php
+++ b/src/Factory/BoardFactory.php
@@ -31,7 +31,23 @@ final class BoardFactory extends PersistentProxyObjectFactory
     protected function defaults(): array|callable
     {
         return [
-            'title' => self::faker()->words(3, true),
+            'title' => fn() => self::faker()->randomElement([
+                'Website Redesign Project',
+                'Mobile App Development',
+                'Marketing Campaign Q4',
+                'Bug Fixes Sprint',
+                'Feature Backlog',
+                'User Research Board',
+                'Team Onboarding',
+                'Product Launch',
+                'Code Review Tasks',
+                'Documentation Updates',
+                'Testing & QA',
+                'Client Projects',
+                'Personal Tasks',
+                'Team Meeting Notes',
+                'Infrastructure Migration'
+            ]),
             'owner' => AccountFactory::new(),
         ];
     }

--- a/src/Factory/CardFactory.php
+++ b/src/Factory/CardFactory.php
@@ -29,28 +29,34 @@ final class CardFactory extends PersistentProxyObjectFactory
      */
     protected function defaults(): array
     {
+        $titles = [
+            'Fix login bug' => 'Investigate and resolve the issue preventing some users from logging in successfully.',
+            'Add user authentication' => 'Implement secure login and registration with hashed passwords and session handling.',
+            'Implement search feature' => 'Allow users to search content using keywords and filters for better navigation.',
+            'Update documentation' => 'Review and update project documentation to reflect the latest changes.',
+            'Code review' => 'Perform a peer review to ensure code quality, maintainability, and adherence to standards.',
+            'Database migration' => 'Create and execute migration scripts to update the schema without data loss.',
+            'Performance optimization' => 'Identify bottlenecks and optimize queries or code to improve response time.',
+            'Security audit' => 'Run a security check for vulnerabilities such as SQL injection or XSS.',
+            'UI/UX improvements' => 'Enhance the interface for better usability and user satisfaction.',
+            'Test automation setup' => 'Introduce automated tests to reduce regressions and ensure reliability.',
+            'API endpoint creation' => 'Develop and document a new API endpoint for client integration.',
+            'Bug investigation' => 'Reproduce, analyze, and document a reported bug before fixing it.',
+            'Feature specification' => 'Write detailed specs to define requirements and acceptance criteria.',
+            'Deploy to production' => 'Prepare release notes, run final checks, and deploy to the live environment.',
+            'Refactor legacy code' => 'Clean up outdated code to improve readability and maintainability.',
+        ];
+
+        $title = self::faker()->randomElement(array_keys($titles));
+
         return [
             'status' => self::faker()->randomElement(['todo', 'in-progress', 'review', 'done', 'blocked']),
-            'title' => self::faker()->randomElement([
-                'Fix login bug',
-                'Add user authentication',
-                'Implement search feature',
-                'Update documentation',
-                'Code review',
-                'Database migration',
-                'Performance optimization',
-                'Security audit',
-                'UI/UX improvements',
-                'Test automation setup',
-                'API endpoint creation',
-                'Bug investigation',
-                'Feature specification',
-                'Deploy to production',
-                'Refactor legacy code',
-            ]),
+            'title' => $title,
+            'description' => self::faker()->optional(0.7)->sentence() . ' ' . $titles[$title],
             'position' => null,
         ];
     }
+
 
 
     /**

--- a/src/Factory/CardFactory.php
+++ b/src/Factory/CardFactory.php
@@ -27,14 +27,31 @@ final class CardFactory extends PersistentProxyObjectFactory
      *
      * @return array<string, mixed>|callable<string, mixed> Default values for the Card entity.
      */
-    protected function defaults(): array|callable
+    protected function defaults(): array
     {
         return [
-            'status' => self::faker()->text(24),
-            'title' => self::faker()->text(50),
+            'status' => self::faker()->randomElement(['todo', 'in-progress', 'review', 'done', 'blocked']),
+            'title' => self::faker()->randomElement([
+                'Fix login bug',
+                'Add user authentication',
+                'Implement search feature',
+                'Update documentation',
+                'Code review',
+                'Database migration',
+                'Performance optimization',
+                'Security audit',
+                'UI/UX improvements',
+                'Test automation setup',
+                'API endpoint creation',
+                'Bug investigation',
+                'Feature specification',
+                'Deploy to production',
+                'Refactor legacy code',
+            ]),
             'position' => null,
         ];
     }
+
 
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization

--- a/src/Factory/CardFactory.php
+++ b/src/Factory/CardFactory.php
@@ -52,7 +52,7 @@ final class CardFactory extends PersistentProxyObjectFactory
         return [
             'status' => self::faker()->randomElement(['todo', 'in-progress', 'review', 'done', 'blocked']),
             'title' => $title,
-            'description' => self::faker()->optional(0.7)->sentence() . ' ' . $titles[$title],
+            'description' => self::faker()->optional(0.7)->sentence(). '' .$titles[$title],
             'position' => null,
         ];
     }

--- a/src/Factory/LaneFactory.php
+++ b/src/Factory/LaneFactory.php
@@ -27,25 +27,23 @@ final class LaneFactory extends PersistentProxyObjectFactory
      *
      * @return array<string, mixed>|callable<string, mixed> Default values for the Lane entity.
      */
-    protected function defaults(): array|callable
+    protected function defaults(): array
     {
         return [
-            'title' => static function () {
-                $labels = [
-                    'Backlog',
-                    'To Do',
-                    'In Progress',
-                    'Blocked',
-                    'In Review',
-                    'Testing',
-                    'Done',
-                    'Archived',
-                ];
-                return self::faker()->randomElement($labels);
-            },
+            'title' => self::faker()->randomElement([
+                'Backlog',
+                'To Do',
+                'In Progress',
+                'Blocked',
+                'In Review',
+                'Testing',
+                'Done',
+                'Archived',
+            ]),
             'position' => null,
         ];
     }
+
 
     /**
      * @see https://symfony.com/bundles/ZenstruckFoundryBundle/current/index.html#initialization

--- a/templates/components/Lane.html.twig
+++ b/templates/components/Lane.html.twig
@@ -9,8 +9,8 @@
 			<label for="card_create_modal_{{ lane.id }}" class="btn btn-xs btn-primary">
 				+ New
 			</label>
-            <label for="lane_edit_modal_{{ lane.id }}" class="btn btn-xs btn-ghost text-slate-400 hover:text-white hover:bg-slate-700/50 ml-2 p-1 min-h-0 h-6 w-6 rounded-md transition-all duration-200">
-				<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+			<label for="lane_edit_modal_{{ lane.id }}" class="btn btn-xs btn-ghost text-slate-400 hover:text-white hover:bg-slate-700/50 ml-2 p-1 min-h-0 h-6 w-6 rounded-md transition-all duration-200">
+				<svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewbox="0 0 24 24">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/>
 				</svg>
 			</label>
@@ -18,9 +18,7 @@
 	</header>
 
 
-	<div class="card-body pt-2 pb-4 px-4 space-y-2 overflow-y-auto max-h-[70vh]"
-		 data-lane-id="{{ lane.id }}"
-		 data-move-url="{{ path('card_move') }}">
+	<div class="card-body lane-cards pt-2 pb-4 px-4 space-y-2 overflow-y-auto max-h-[70vh]" data-lane-id="{{ lane.id }}" data-move-url="{{ path('card_move') }}">
 		{% for card in lane.cards|sort((a,b) => a.position <=> b.position) %}
 			<div data-card-id="{{ card.id }}">
 				{% include 'components/Card.html.twig' with { card: card } %}


### PR DESCRIPTION
This pull request updates the default data generation for the `Board`, `Lane`, and `Card` factories to use more realistic and descriptive values, and makes a minor fix to the `Lane.html.twig` template. The changes improve the quality and clarity of test and seed data, which will make development and testing easier and more meaningful.

**Factory improvements:**

* The `defaults()` method in `BoardFactory`, `LaneFactory`, and `CardFactory` now always returns an array instead of supporting both arrays and callables, simplifying the code and aligning with current usage
* `BoardFactory`; The `title` field now uses a random selection from a list of realistic board names (e.g., "Website Redesign Project", "Bug Fixes Sprint") instead of random words.
* `LaneFactory`: The `title` field now uses a random selection from a list of standard lane names (e.g., "Backlog", "In Progress", "Done") directly, removing the unnecessary closure and simplifying the code. : The `title` and `description` fields now use a predefined set of realistic task titles and corresponding descriptions, and the `status` field is now selected from a set of standard workflow statuses (e.g., "todo", "in-progress").

**Template fix:**
* In `Lane.html.twig`, the `svg` element's `viewBox` attribute is corrected to `viewbox`, and the `card-body` div receives a new class `lane-cards` for possible future styling or scripting.