### PR TITLE
ci: add GitHub Actions workflow (lint + PHPUnit on MariaDB 11.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: intl, pdo_mysql, zip
+          coverage: none
+
+      - name: Validate composer.json
+        run: composer validate --no-check-publish
+
+      - name: Install dependencies
+        uses: ramsey/composer-install@v3
+
+      - name: Lint service container
+        run: php bin/console lint:container
+
+      - name: Lint Twig templates
+        run: php bin/console lint:twig templates
+
+      - name: Lint YAML configuration
+        run: php bin/console lint:yaml config --parse-tags
+
+  tests:
+    name: Tests (PHPUnit)
+    runs-on: ubuntu-latest
+    services:
+      database:
+        image: mariadb:11.4
+        env:
+          MARIADB_ROOT_PASSWORD: root
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=10
+    env:
+      # Real env vars take precedence over .env.test; doctrine appends the
+      # "_test" suffix configured in when@test, so tests run on "taskio_test".
+      DATABASE_URL: 'mysql://root:root@127.0.0.1:3306/taskio?serverVersion=11.4.2-MariaDB&charset=utf8mb4'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: intl, pdo_mysql, zip
+          coverage: none
+
+      - name: Install dependencies
+        uses: ramsey/composer-install@v3
+
+      - name: Run test suite
+        run: php bin/phpunit

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Taskio - Collaborative Board Management System
 
+[![CI](https://github.com/Baylox/taskio/actions/workflows/ci.yml/badge.svg)](https://github.com/Baylox/taskio/actions/workflows/ci.yml)
 [![PHP](https://img.shields.io/badge/PHP-8.2%2B-777BB4?logo=php&logoColor=white)](https://www.php.net/)
 [![Symfony](https://img.shields.io/badge/Symfony-7.3-000000?logo=symfony&logoColor=white)](https://symfony.com/)
 [![MariaDB](https://img.shields.io/badge/MariaDB-11.4-003545?logo=mariadb&logoColor=white)](https://mariadb.org/)


### PR DESCRIPTION
## Summary

Adds the first CI pipeline for the repository — until now the 131-test suite only ran locally and nothing protected `main`.

Two jobs run on every push to `main` and every pull request:

- **Lint** — `composer validate`, `lint:container`, `lint:twig`, `lint:yaml`
- **Tests (PHPUnit)** — the full suite (unit + functional) against a **MariaDB 11.4** service, matching the `compose.yaml` database image; hermetic thanks to the Vite manifest stubs and offline validator config already in the repo

Also adds the CI status badge to the README.

## Notes

- `composer validate` uses `--no-check-publish` (the project is an application, not a published package).
- The database healthcheck uses the official `healthcheck.sh` script of the MariaDB image (the `mysql*` binaries no longer exist in `mariadb:11+`).
- Test coverage gaps (BoardInvitationService, CardMover, repository queries, public-page smoke tests) are intentionally **not** part of this PR — they land in a separate follow-up PR so this one stays reviewable.
