### PR TITLE
test: fill the coverage gaps left by the architecture refactor

### DIFF
--- a/tests/Functional/Controller/BoardInvitationFlowTest.php
+++ b/tests/Functional/Controller/BoardInvitationFlowTest.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace App\Tests\Functional\Controller;
+
+use App\Entity\Account;
+use App\Entity\BoardInvitation;
+use App\Factory\AccountFactory;
+use App\Factory\BoardFactory;
+use App\Repository\BoardInvitationRepository;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * Exercises the collaborator invitation flow end to end:
+ * invite by email, duplicate protection, token acceptance, cancellation and removal.
+ *
+ * Note: BoardFactory::initialize() automatically attaches two collaborator
+ * accounts to every board, which the membership assertions below rely on.
+ */
+final class BoardInvitationFlowTest extends WebTestCase
+{
+    use ResetDatabase;
+    use Factories;
+
+    private const INVITEE_EMAIL = 'invitee@example.com';
+
+    public function testOwnerCanInviteCollaboratorByEmail(): void
+    {
+        $client = static::createClient();
+        $owner = AccountFactory::createOne();
+        $board = BoardFactory::createOne(['owner' => $owner]);
+        $client->loginUser($owner->_real());
+
+        $crawler = $client->request('GET', '/board/' . $board->getId() . '/edit');
+        $this->assertResponseIsSuccessful();
+
+        $client->submit($crawler->selectButton('Send Invitation')->form([
+            'add_collaborator[email]' => self::INVITEE_EMAIL,
+        ]));
+
+        $this->assertResponseRedirects('/board/' . $board->getId() . '/edit');
+        $this->assertEmailCount(1);
+
+        $invitation = static::getContainer()->get(BoardInvitationRepository::class)
+            ->findOneBy(['email' => self::INVITEE_EMAIL, 'board' => $board->getId()]);
+        $this->assertNotNull($invitation);
+        $this->assertFalse($invitation->isAccepted());
+    }
+
+    public function testInvitingSameEmailTwiceDoesNotCreateDuplicate(): void
+    {
+        $client = static::createClient();
+        $owner = AccountFactory::createOne();
+        $board = BoardFactory::createOne(['owner' => $owner]);
+        $client->loginUser($owner->_real());
+
+        $editUrl = '/board/' . $board->getId() . '/edit';
+
+        $crawler = $client->request('GET', $editUrl);
+        $client->submit($crawler->selectButton('Send Invitation')->form([
+            'add_collaborator[email]' => self::INVITEE_EMAIL,
+        ]));
+
+        $crawler = $client->request('GET', $editUrl);
+        $client->submit($crawler->selectButton('Send Invitation')->form([
+            'add_collaborator[email]' => self::INVITEE_EMAIL,
+        ]));
+
+        $this->assertResponseRedirects($editUrl);
+        // Enumeration-safe: the duplicate is silently ignored, no second email leaves.
+        $this->assertEmailCount(0);
+
+        $this->assertSame(1, static::getContainer()->get(BoardInvitationRepository::class)
+            ->count(['email' => self::INVITEE_EMAIL, 'board' => $board->getId()]));
+    }
+
+    public function testInvitedUserBecomesMemberWhenAcceptingValidToken(): void
+    {
+        $client = static::createClient();
+        $owner = AccountFactory::createOne();
+        $board = BoardFactory::createOne(['owner' => $owner]);
+        $invitee = AccountFactory::createOne(['email' => self::INVITEE_EMAIL]);
+
+        $invitation = new BoardInvitation();
+        $invitation->setBoard($board->_real());
+        $invitation->setEmail(self::INVITEE_EMAIL);
+        $invitation->setInvitedBy($owner->_real());
+        static::getContainer()->get(BoardInvitationRepository::class)->save($invitation);
+
+        $client->loginUser($invitee->_real());
+        $client->request('GET', '/board/invitation/' . $invitation->getToken() . '/accept');
+
+        $this->assertResponseRedirects('/board/' . $board->getId() . '/edit');
+
+        $board->_refresh();
+        $memberIds = $board->getAccounts()->map(fn (Account $account) => $account->getId())->toArray();
+        $this->assertContains($invitee->getId(), $memberIds);
+
+        $accepted = static::getContainer()->get(BoardInvitationRepository::class)->find($invitation->getId());
+        $this->assertNotNull($accepted);
+        $this->assertTrue($accepted->isAccepted());
+    }
+
+    public function testUnknownTokenRedirectsToBoardIndex(): void
+    {
+        $client = static::createClient();
+        $client->loginUser(AccountFactory::createOne()->_real());
+
+        $client->request('GET', '/board/invitation/' . str_repeat('0', 64) . '/accept');
+
+        // The controller flashes an error and sends the user back to the board list.
+        $this->assertResponseRedirects('/board');
+    }
+
+    public function testOwnerCanCancelPendingInvitation(): void
+    {
+        $client = static::createClient();
+        $owner = AccountFactory::createOne();
+        $board = BoardFactory::createOne(['owner' => $owner]);
+
+        $invitation = new BoardInvitation();
+        $invitation->setBoard($board->_real());
+        $invitation->setEmail(self::INVITEE_EMAIL);
+        $invitation->setInvitedBy($owner->_real());
+        static::getContainer()->get(BoardInvitationRepository::class)->save($invitation);
+        $invitationId = $invitation->getId();
+
+        $client->loginUser($owner->_real());
+        $crawler = $client->request('GET', '/board/' . $board->getId() . '/edit');
+
+        // Submit the rendered cancel form so the CSRF token is the real one.
+        $cancelAction = '/board/' . $board->getId() . '/invitation/' . $invitationId . '/cancel';
+        $client->submit($crawler->filter('form[action="' . $cancelAction . '"]')->form());
+
+        $this->assertResponseRedirects('/board/' . $board->getId() . '/edit');
+        $this->assertNull(static::getContainer()->get(BoardInvitationRepository::class)->find($invitationId));
+    }
+
+    public function testOwnerCanRemoveCollaborator(): void
+    {
+        $client = static::createClient();
+        $owner = AccountFactory::createOne();
+        $board = BoardFactory::createOne(['owner' => $owner]);
+
+        // BoardFactory auto-attaches two collaborators; remove the first one.
+        $collaboratorId = $board->getAccounts()->first()->getId();
+
+        $client->loginUser($owner->_real());
+        $crawler = $client->request('GET', '/board/' . $board->getId() . '/edit');
+
+        $removeAction = '/board/' . $board->getId() . '/collaborator/' . $collaboratorId . '/remove';
+        $client->submit($crawler->filter('form[action="' . $removeAction . '"]')->form());
+
+        $this->assertResponseRedirects('/board/' . $board->getId() . '/edit');
+
+        $board->_refresh();
+        $memberIds = $board->getAccounts()->map(fn (Account $account) => $account->getId())->toArray();
+        $this->assertNotContains($collaboratorId, $memberIds);
+        $this->assertCount(1, $board->getAccounts());
+    }
+
+    public function testMemberWithoutManagePermissionCannotInvite(): void
+    {
+        $client = static::createClient();
+        $owner = AccountFactory::createOne();
+        $board = BoardFactory::createOne(['owner' => $owner]);
+
+        // A plain collaborator (auto-created by BoardFactory) is not the owner.
+        $member = $board->getAccounts()->first();
+        $client->loginUser($member);
+
+        $client->request('POST', '/board/' . $board->getId() . '/collaborator/invite');
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+}

--- a/tests/Functional/Controller/PublicPagesTest.php
+++ b/tests/Functional/Controller/PublicPagesTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Tests\Functional\Controller;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Smoke tests for the anonymous public pages (marketing + authentication entry points).
+ *
+ * None of these pages read or write the database, so this test intentionally
+ * skips ResetDatabase/Factories to stay fast.
+ */
+final class PublicPagesTest extends WebTestCase
+{
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function publicPathProvider(): iterable
+    {
+        yield 'home' => ['/'];
+        yield 'solutions' => ['/solutions'];
+        yield 'roadmap' => ['/roadmap'];
+        yield 'contact' => ['/contact'];
+        yield 'login' => ['/login'];
+        yield 'register' => ['/register'];
+    }
+
+    #[DataProvider('publicPathProvider')]
+    public function testPublicPageRespondsSuccessfully(string $path): void
+    {
+        $client = static::createClient();
+        $client->request('GET', $path);
+
+        $this->assertResponseIsSuccessful();
+    }
+
+    public function testRemovedPricingPageReturnsNotFound(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/price');
+
+        // The pricing page was removed on purpose; this locks in its absence.
+        $this->assertResponseStatusCodeSame(404);
+    }
+}

--- a/tests/Integration/Repository/BoardInvitationRepositoryTest.php
+++ b/tests/Integration/Repository/BoardInvitationRepositoryTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace App\Tests\Integration\Repository;
+
+use App\Entity\Board;
+use App\Entity\BoardInvitation;
+use App\Factory\BoardFactory;
+use App\Repository\BoardInvitationRepository;
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * Exercises BoardInvitationRepository queries against a real database.
+ *
+ * There is no BoardInvitation factory: invitations are built by hand and
+ * persisted through the repository. The entity constructor generates the
+ * token and a "+7 days" expiry, so a freshly built invitation is pending.
+ */
+#[CoversClass(BoardInvitationRepository::class)]
+final class BoardInvitationRepositoryTest extends KernelTestCase
+{
+    use ResetDatabase;
+    use Factories;
+
+    private BoardInvitationRepository $repository;
+
+    protected function setUp(): void
+    {
+        $this->repository = static::getContainer()->get(BoardInvitationRepository::class);
+    }
+
+    /**
+     * Build a pending invitation for the given board (not persisted yet).
+     */
+    private function makeInvitation(Board $board, string $email): BoardInvitation
+    {
+        $invitation = new BoardInvitation();
+        $invitation->setBoard($board);
+        $invitation->setEmail($email);
+        $invitation->setInvitedBy($board->getOwner());
+
+        return $invitation;
+    }
+
+    public function testFindPendingByEmailAndBoardReturnsPendingInvitation(): void
+    {
+        $board = BoardFactory::createOne()->_real();
+
+        $invitation = $this->makeInvitation($board, 'invitee@example.com');
+        $this->repository->save($invitation);
+
+        $found = $this->repository->findPendingByEmailAndBoard('invitee@example.com', $board);
+
+        $this->assertNotNull($found);
+        $this->assertSame($invitation->getId(), $found->getId());
+    }
+
+    public function testFindPendingByEmailAndBoardNormalizesTheSearchedEmail(): void
+    {
+        $board = BoardFactory::createOne()->_real();
+
+        $invitation = $this->makeInvitation($board, 'invitee@example.com');
+        $this->repository->save($invitation);
+
+        // The repository lowercases and trims the searched email before comparing.
+        $found = $this->repository->findPendingByEmailAndBoard('  INVITEE@Example.COM  ', $board);
+
+        $this->assertNotNull($found);
+        $this->assertSame($invitation->getId(), $found->getId());
+    }
+
+    public function testFindPendingByEmailAndBoardIgnoresAcceptedInvitations(): void
+    {
+        $board = BoardFactory::createOne()->_real();
+
+        $invitation = $this->makeInvitation($board, 'invitee@example.com');
+        $invitation->setIsAccepted(true);
+        $this->repository->save($invitation);
+
+        $this->assertNull($this->repository->findPendingByEmailAndBoard('invitee@example.com', $board));
+    }
+
+    public function testFindPendingByEmailAndBoardIgnoresExpiredInvitations(): void
+    {
+        $board = BoardFactory::createOne()->_real();
+
+        $invitation = $this->makeInvitation($board, 'invitee@example.com');
+        $invitation->setExpiresAt(new DateTimeImmutable('-1 hour'));
+        $this->repository->save($invitation);
+
+        $this->assertNull($this->repository->findPendingByEmailAndBoard('invitee@example.com', $board));
+    }
+
+    public function testFindPendingByEmailAndBoardIsScopedToEmailAndBoard(): void
+    {
+        $board = BoardFactory::createOne()->_real();
+        $otherBoard = BoardFactory::createOne()->_real();
+
+        $this->repository->save($this->makeInvitation($board, 'invitee@example.com'));
+
+        // Same board, different email: no match.
+        $this->assertNull($this->repository->findPendingByEmailAndBoard('someone.else@example.com', $board));
+        // Same email, different board: no match.
+        $this->assertNull($this->repository->findPendingByEmailAndBoard('invitee@example.com', $otherBoard));
+    }
+
+    public function testSavePersistsInvitationWithConstructorDefaults(): void
+    {
+        $board = BoardFactory::createOne()->_real();
+
+        $invitation = $this->makeInvitation($board, 'invitee@example.com');
+        $this->repository->save($invitation);
+
+        $this->assertNotNull($invitation->getId());
+        $this->assertSame(64, strlen((string) $invitation->getToken()));
+        $this->assertFalse($invitation->isAccepted());
+        $this->assertNull($invitation->getAcceptedAt());
+        $this->assertNotNull($invitation->getCreatedAt());
+        $this->assertGreaterThan(new DateTimeImmutable(), $invitation->getExpiresAt());
+    }
+
+    public function testRemoveDeletesInvitation(): void
+    {
+        $board = BoardFactory::createOne()->_real();
+
+        $invitation = $this->makeInvitation($board, 'invitee@example.com');
+        $this->repository->save($invitation);
+
+        $id = $invitation->getId();
+        $this->assertNotNull($id);
+
+        $this->repository->remove($invitation);
+
+        $this->assertNull($this->repository->find($id));
+    }
+}

--- a/tests/Integration/Repository/BoardRepositoryTest.php
+++ b/tests/Integration/Repository/BoardRepositoryTest.php
@@ -1,0 +1,209 @@
+<?php
+
+namespace App\Tests\Integration\Repository;
+
+use App\Entity\Board;
+use App\Entity\Card;
+use App\Entity\Lane;
+use App\Factory\AccountFactory;
+use App\Factory\BoardFactory;
+use App\Factory\CardFactory;
+use App\Factory\LaneFactory;
+use App\Repository\BoardRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * Exercises BoardRepository queries against a real database.
+ *
+ * Note: BoardFactory::initialize() automatically attaches two freshly created
+ * member accounts to every board it builds; the assertions below are written
+ * with those extra members in mind.
+ */
+#[CoversClass(BoardRepository::class)]
+final class BoardRepositoryTest extends KernelTestCase
+{
+    use ResetDatabase;
+    use Factories;
+
+    private BoardRepository $repository;
+    private EntityManagerInterface $em;
+
+    protected function setUp(): void
+    {
+        $container = static::getContainer();
+        $this->repository = $container->get(BoardRepository::class);
+        $this->em = $container->get(EntityManagerInterface::class);
+    }
+
+    public function testFindVisibleForUserReturnsOwnedAndMemberBoardsWithoutDuplicates(): void
+    {
+        $user = AccountFactory::createOne();
+
+        // Owned only: visible even though the user is not a member.
+        $ownedBoard = BoardFactory::createOne(['owner' => $user]);
+
+        // Member only: visible even though someone else owns it.
+        $memberBoard = BoardFactory::createOne();
+
+        // Owner AND member: must appear only once thanks to distinct().
+        $ownedAndMemberBoard = BoardFactory::createOne(['owner' => $user]);
+
+        // Unrelated board (foreign owner, auto-created members only): excluded.
+        BoardFactory::createOne();
+
+        // Capture the real entity once: every _real() call on a proxy that was
+        // flushed since may auto-refresh the entity and silently discard the
+        // not-yet-flushed collection change made through the previous call.
+        $realUser = $user->_real();
+        $memberBoard->_real()->addAccount($realUser);
+        $ownedAndMemberBoard->_real()->addAccount($realUser);
+        $this->em->flush();
+
+        $boards = $this->repository->findVisibleForUser($user->_real());
+
+        $this->assertSame(
+            [$ownedBoard->getId(), $memberBoard->getId(), $ownedAndMemberBoard->getId()],
+            array_map(static fn (Board $board): int => $board->getId(), $boards)
+        );
+    }
+
+    public function testIsBoardMemberDistinguishesMembersFromOwnerAndStrangers(): void
+    {
+        $owner = AccountFactory::createOne();
+        $member = AccountFactory::createOne();
+        $stranger = AccountFactory::createOne();
+
+        $board = BoardFactory::createOne(['owner' => $owner]);
+        $board->_real()->addAccount($member->_real());
+        $this->em->flush();
+
+        $this->assertTrue($this->repository->isBoardMember($board->_real(), $member->_real()));
+        // Owning a board does not make the owner a member.
+        $this->assertFalse($this->repository->isBoardMember($board->_real(), $owner->_real()));
+        $this->assertFalse($this->repository->isBoardMember($board->_real(), $stranger->_real()));
+    }
+
+    public function testFindByAccountReturnsOnlyBoardsWhereAccountIsMember(): void
+    {
+        $account = AccountFactory::createOne();
+
+        // Owner only: must not be returned by findByAccount().
+        BoardFactory::createOne(['owner' => $account]);
+
+        $memberBoard = BoardFactory::createOne();
+        $memberBoard->_real()->addAccount($account->_real());
+        $this->em->flush();
+
+        $boards = $this->repository->findByAccount($account->_real());
+
+        $this->assertCount(1, $boards);
+        $this->assertSame($memberBoard->getId(), $boards[0]->getId());
+    }
+
+    public function testFindWithLanesAndCardsReturnsNullForUnknownId(): void
+    {
+        $this->assertNull($this->repository->findWithLanesAndCards(999999));
+    }
+
+    public function testFindWithLanesAndCardsOrdersLanesAndCardsByPosition(): void
+    {
+        $board = BoardFactory::createOne();
+
+        // Created out of order on purpose: the query must sort by position.
+        $secondLane = LaneFactory::createOne(['board' => $board, 'title' => 'Second lane', 'position' => 2]);
+        $firstLane = LaneFactory::createOne(['board' => $board, 'title' => 'First lane', 'position' => 1]);
+
+        CardFactory::createOne(['lane' => $firstLane, 'title' => 'Second card', 'position' => 2]);
+        CardFactory::createOne(['lane' => $firstLane, 'title' => 'First card', 'position' => 1]);
+
+        $boardId = $board->getId();
+        $secondLaneId = $secondLane->getId();
+
+        // Detach everything so the collections are hydrated by the query under test.
+        $this->em->clear();
+
+        $found = $this->repository->findWithLanesAndCards($boardId);
+
+        $this->assertNotNull($found);
+        $this->assertSame($boardId, $found->getId());
+
+        $lanes = $found->getLanes()->toArray();
+        $this->assertCount(2, $lanes);
+        $this->assertSame(
+            ['First lane', 'Second lane'],
+            array_map(static fn (Lane $lane): string => $lane->getTitle(), $lanes)
+        );
+        $this->assertSame($secondLaneId, $lanes[1]->getId());
+
+        $cards = $lanes[0]->getCards()->toArray();
+        $this->assertCount(2, $cards);
+        $this->assertSame(
+            ['First card', 'Second card'],
+            array_map(static fn (Card $card): string => $card->getTitle(), $cards)
+        );
+    }
+
+    public function testQbForAdminWithoutSearchReturnsAllBoardsOrderedByTitle(): void
+    {
+        BoardFactory::createOne(['title' => 'Zephyr Roadmap']);
+        BoardFactory::createOne(['title' => 'Alpha Backlog']);
+
+        $boards = $this->repository->qbForAdmin(null)->getQuery()->getResult();
+
+        $this->assertSame(
+            ['Alpha Backlog', 'Zephyr Roadmap'],
+            array_map(static fn (Board $board): string => $board->getTitle(), $boards)
+        );
+
+        // An empty search string is treated the same as no search at all.
+        $this->assertCount(2, $this->repository->qbForAdmin('')->getQuery()->getResult());
+    }
+
+    public function testQbForAdminFiltersByTitleFragmentCaseInsensitively(): void
+    {
+        BoardFactory::createOne(['title' => 'Zephyr Roadmap']);
+        BoardFactory::createOne(['title' => 'Alpha Backlog']);
+
+        $boards = $this->repository->qbForAdmin('zEpHyR')->getQuery()->getResult();
+
+        $this->assertCount(1, $boards);
+        $this->assertSame('Zephyr Roadmap', $boards[0]->getTitle());
+    }
+
+    public function testQbForAdminFiltersByOwnerEmailFragmentCaseInsensitively(): void
+    {
+        $matchingOwner = AccountFactory::createOne(['email' => 'quartz.owner@example.test']);
+        $otherOwner = AccountFactory::createOne(['email' => 'other.owner@example.test']);
+
+        $matchingBoard = BoardFactory::createOne(['title' => 'First board', 'owner' => $matchingOwner]);
+        BoardFactory::createOne(['title' => 'Second board', 'owner' => $otherOwner]);
+
+        $boards = $this->repository->qbForAdmin('QUARTZ')->getQuery()->getResult();
+
+        $this->assertCount(1, $boards);
+        $this->assertSame($matchingBoard->getId(), $boards[0]->getId());
+    }
+
+    public function testSavePersistsAndRemoveDeletesBoard(): void
+    {
+        $owner = AccountFactory::createOne();
+
+        $board = new Board();
+        $board->setTitle('Persisted by repository');
+        $board->setOwner($owner->_real());
+
+        $this->repository->save($board);
+
+        $id = $board->getId();
+        $this->assertNotNull($id);
+        $this->assertNotNull($this->repository->find($id));
+
+        $this->repository->remove($board);
+
+        $this->assertNull($this->repository->find($id));
+    }
+}

--- a/tests/Integration/Repository/CardRepositoryTest.php
+++ b/tests/Integration/Repository/CardRepositoryTest.php
@@ -1,0 +1,280 @@
+<?php
+
+namespace App\Tests\Integration\Repository;
+
+use App\Entity\Card;
+use App\Enum\CardStatus;
+use App\Factory\BoardFactory;
+use App\Factory\CardFactory;
+use App\Factory\LaneFactory;
+use App\Repository\CardRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * Exercises CardRepository against a real database.
+ *
+ * compactAfterRemoval, makeRoomAt and shiftWithinLane are DQL bulk UPDATEs that
+ * bypass the Doctrine identity map: the tests call EntityManager::clear() after
+ * executing them and re-read the positions from the database before asserting.
+ *
+ * Several scenarios use non-contiguous positions on purpose: the card table has
+ * a UNIQUE(lane_id, position) constraint and MariaDB validates unique keys row
+ * by row while a multi-row UPDATE runs, so shifting a dense sequence could raise
+ * a transient duplicate-key error depending on the scan order. Gaps keep the
+ * interval semantics under test deterministic.
+ */
+#[CoversClass(CardRepository::class)]
+final class CardRepositoryTest extends KernelTestCase
+{
+    use ResetDatabase;
+    use Factories;
+
+    public function testFindMaxPositionInLaneReturnsHighestPosition(): void
+    {
+        $board = BoardFactory::createOne();
+        $lane = LaneFactory::createOne(['board' => $board, 'position' => 1]);
+        $otherLane = LaneFactory::createOne(['board' => $board, 'position' => 2]);
+
+        CardFactory::createOne(['lane' => $lane, 'position' => 0]);
+        CardFactory::createOne(['lane' => $lane, 'position' => 2]);
+        CardFactory::createOne(['lane' => $lane, 'position' => 5]);
+        // A higher position in another lane must not leak into the result.
+        CardFactory::createOne(['lane' => $otherLane, 'position' => 9]);
+
+        $this->assertSame(5, $this->repository()->findMaxPositionInLane($lane->_real()));
+    }
+
+    public function testFindMaxPositionInLaneReturnsZeroForAnEmptyLane(): void
+    {
+        $board = BoardFactory::createOne();
+        $emptyLane = LaneFactory::createOne(['board' => $board, 'position' => 1]);
+        $otherLane = LaneFactory::createOne(['board' => $board, 'position' => 2]);
+
+        CardFactory::createOne(['lane' => $otherLane, 'position' => 3]);
+
+        $this->assertSame(0, $this->repository()->findMaxPositionInLane($emptyLane->_real()));
+    }
+
+    public function testFindIdsByLaneOrderedReturnsIdsSortedByAscendingPosition(): void
+    {
+        $board = BoardFactory::createOne();
+        $lane = LaneFactory::createOne(['board' => $board, 'position' => 1]);
+        $otherLane = LaneFactory::createOne(['board' => $board, 'position' => 2]);
+
+        // Created out of order so insertion order cannot mask the sorting.
+        $last = CardFactory::createOne(['lane' => $lane, 'position' => 2]);
+        $first = CardFactory::createOne(['lane' => $lane, 'position' => 0]);
+        $middle = CardFactory::createOne(['lane' => $lane, 'position' => 1]);
+        // Cards from another lane must not be listed.
+        CardFactory::createOne(['lane' => $otherLane, 'position' => 0]);
+
+        $this->assertSame(
+            [$first->getId(), $middle->getId(), $last->getId()],
+            $this->repository()->findIdsByLaneOrdered($lane->_real())
+        );
+    }
+
+    public function testCompactAfterRemovalDecrementsOnlyPositionsAboveTheRemovedOne(): void
+    {
+        $board = BoardFactory::createOne();
+        $lane = LaneFactory::createOne(['board' => $board, 'position' => 1]);
+        $otherLane = LaneFactory::createOne(['board' => $board, 'position' => 2]);
+
+        $below = CardFactory::createOne(['lane' => $lane, 'position' => 0]);
+        $removed = CardFactory::createOne(['lane' => $lane, 'position' => 1]);
+        $above = CardFactory::createOne(['lane' => $lane, 'position' => 2]);
+        $other = CardFactory::createOne(['lane' => $otherLane, 'position' => 2]);
+
+        $belowId = $below->getId();
+        $aboveId = $above->getId();
+        $otherId = $other->getId();
+
+        // The contract is "after removing a card at $oldPos": delete it first.
+        $this->repository()->remove($removed->_real());
+
+        $affected = $this->repository()->compactAfterRemoval($lane->_real(), 1);
+
+        $this->assertSame(1, $affected);
+
+        $this->em()->clear();
+
+        $this->assertCardPosition($belowId, 0);
+        $this->assertCardPosition($aboveId, 1);
+        // Another lane sharing the same position values is left untouched.
+        $this->assertCardPosition($otherId, 2);
+    }
+
+    public function testMakeRoomAtIncrementsOnlyPositionsAtOrAboveTheIndex(): void
+    {
+        $board = BoardFactory::createOne();
+        $lane = LaneFactory::createOne(['board' => $board, 'position' => 1]);
+        $otherLane = LaneFactory::createOne(['board' => $board, 'position' => 2]);
+
+        $below = CardFactory::createOne(['lane' => $lane, 'position' => 0]);
+        $atIndex = CardFactory::createOne(['lane' => $lane, 'position' => 3]);
+        $above = CardFactory::createOne(['lane' => $lane, 'position' => 7]);
+        $other = CardFactory::createOne(['lane' => $otherLane, 'position' => 3]);
+
+        $belowId = $below->getId();
+        $atIndexId = $atIndex->getId();
+        $aboveId = $above->getId();
+        $otherId = $other->getId();
+
+        $affected = $this->repository()->makeRoomAt($lane->_real(), 3);
+
+        $this->assertSame(2, $affected);
+
+        $this->em()->clear();
+
+        $this->assertCardPosition($belowId, 0);
+        $this->assertCardPosition($atIndexId, 4);
+        $this->assertCardPosition($aboveId, 8);
+        $this->assertCardPosition($otherId, 3);
+    }
+
+    public function testShiftWithinLaneWithGreaterNewIndexDecrementsTheHalfOpenInterval(): void
+    {
+        $board = BoardFactory::createOne();
+        $lane = LaneFactory::createOne(['board' => $board, 'position' => 1]);
+
+        $atOldIndex = CardFactory::createOne(['lane' => $lane, 'position' => 0]);
+        $inInterval = CardFactory::createOne(['lane' => $lane, 'position' => 2]);
+        $atNewIndex = CardFactory::createOne(['lane' => $lane, 'position' => 6]);
+        $outside = CardFactory::createOne(['lane' => $lane, 'position' => 9]);
+
+        $atOldIndexId = $atOldIndex->getId();
+        $inIntervalId = $inInterval->getId();
+        $atNewIndexId = $atNewIndex->getId();
+        $outsideId = $outside->getId();
+
+        // new > old: positions in (old..new] move down by one.
+        $affected = $this->repository()->shiftWithinLane($lane->_real(), 0, 6);
+
+        $this->assertSame(2, $affected);
+
+        $this->em()->clear();
+
+        // Lower bound is exclusive, upper bound inclusive.
+        $this->assertCardPosition($atOldIndexId, 0);
+        $this->assertCardPosition($inIntervalId, 1);
+        $this->assertCardPosition($atNewIndexId, 5);
+        $this->assertCardPosition($outsideId, 9);
+    }
+
+    public function testShiftWithinLaneWithLowerNewIndexIncrementsTheHalfOpenInterval(): void
+    {
+        $board = BoardFactory::createOne();
+        $lane = LaneFactory::createOne(['board' => $board, 'position' => 1]);
+
+        $below = CardFactory::createOne(['lane' => $lane, 'position' => 0]);
+        $atNewIndex = CardFactory::createOne(['lane' => $lane, 'position' => 3]);
+        $inInterval = CardFactory::createOne(['lane' => $lane, 'position' => 7]);
+        $atOldIndex = CardFactory::createOne(['lane' => $lane, 'position' => 9]);
+
+        $belowId = $below->getId();
+        $atNewIndexId = $atNewIndex->getId();
+        $inIntervalId = $inInterval->getId();
+        $atOldIndexId = $atOldIndex->getId();
+
+        // new < old: positions in [new..old) move up by one.
+        $affected = $this->repository()->shiftWithinLane($lane->_real(), 9, 3);
+
+        $this->assertSame(2, $affected);
+
+        $this->em()->clear();
+
+        // Lower bound is inclusive, upper bound exclusive.
+        $this->assertCardPosition($belowId, 0);
+        $this->assertCardPosition($atNewIndexId, 4);
+        $this->assertCardPosition($inIntervalId, 8);
+        $this->assertCardPosition($atOldIndexId, 9);
+    }
+
+    public function testShiftWithinLaneWithSameIndexIsANoOp(): void
+    {
+        $board = BoardFactory::createOne();
+        $lane = LaneFactory::createOne(['board' => $board, 'position' => 1]);
+
+        $first = CardFactory::createOne(['lane' => $lane, 'position' => 0]);
+        $second = CardFactory::createOne(['lane' => $lane, 'position' => 1]);
+        $third = CardFactory::createOne(['lane' => $lane, 'position' => 2]);
+
+        $firstId = $first->getId();
+        $secondId = $second->getId();
+        $thirdId = $third->getId();
+
+        $this->assertSame(0, $this->repository()->shiftWithinLane($lane->_real(), 1, 1));
+
+        $this->em()->clear();
+
+        $this->assertCardPosition($firstId, 0);
+        $this->assertCardPosition($secondId, 1);
+        $this->assertCardPosition($thirdId, 2);
+    }
+
+    public function testSavePersistsACard(): void
+    {
+        $board = BoardFactory::createOne();
+        $lane = LaneFactory::createOne(['board' => $board, 'position' => 1]);
+
+        $card = (new Card())
+            ->setTitle('Persisted via repository')
+            ->setDescription('Written by CardRepository::save().')
+            ->setStatus(CardStatus::TODO)
+            ->setLane($lane->_real())
+            ->setPosition(0);
+
+        $this->repository()->save($card);
+
+        $id = $card->getId();
+        $this->assertNotNull($id);
+
+        $this->em()->clear();
+
+        $reloaded = $this->repository()->find($id);
+        $this->assertNotNull($reloaded);
+        $this->assertSame('Persisted via repository', $reloaded->getTitle());
+        $this->assertSame(0, $reloaded->getPosition());
+    }
+
+    public function testRemoveDeletesACard(): void
+    {
+        $board = BoardFactory::createOne();
+        $lane = LaneFactory::createOne(['board' => $board, 'position' => 1]);
+        $card = CardFactory::createOne(['lane' => $lane, 'position' => 0]);
+        $id = $card->getId();
+
+        $this->repository()->remove($card->_real());
+
+        $this->em()->clear();
+
+        $this->assertNull($this->repository()->find($id));
+    }
+
+    private function repository(): CardRepository
+    {
+        return static::getContainer()->get(CardRepository::class);
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        return static::getContainer()->get(EntityManagerInterface::class);
+    }
+
+    /**
+     * Asserts a card position as stored in the database. EntityManager::clear()
+     * must have been called after a DQL bulk UPDATE so the card is re-hydrated
+     * from the database instead of the stale identity map.
+     */
+    private function assertCardPosition(int $cardId, int $expectedPosition): void
+    {
+        $card = $this->em()->find(Card::class, $cardId);
+
+        $this->assertNotNull($card, sprintf('Card %d should exist.', $cardId));
+        $this->assertSame($expectedPosition, $card->getPosition());
+    }
+}

--- a/tests/Integration/Service/Board/CardMoverTest.php
+++ b/tests/Integration/Service/Board/CardMoverTest.php
@@ -1,0 +1,159 @@
+<?php
+
+namespace App\Tests\Integration\Service\Board;
+
+use App\Entity\Card;
+use App\Factory\BoardFactory;
+use App\Factory\CardFactory;
+use App\Factory\LaneFactory;
+use App\Service\Board\CardMover;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Zenstruck\Foundry\Test\Factories;
+use Zenstruck\Foundry\Test\ResetDatabase;
+
+/**
+ * Exercises CardMover against a real database (transaction + locks + DQL bulk updates).
+ *
+ * The repository helpers the mover delegates to (compactAfterRemoval, makeRoomAt,
+ * shiftWithinLane) are DQL UPDATE statements that bypass the Doctrine identity map,
+ * so every scenario clears the entity manager after the move and re-reads the
+ * positions from the database before asserting.
+ */
+#[CoversClass(CardMover::class)]
+final class CardMoverTest extends KernelTestCase
+{
+    use ResetDatabase;
+    use Factories;
+
+    public function testMoveToAnotherLaneCompactsSourceAndMakesRoomInTarget(): void
+    {
+        $board = BoardFactory::createOne();
+        $laneA = LaneFactory::createOne(['board' => $board, 'position' => 1]);
+        $laneB = LaneFactory::createOne(['board' => $board, 'position' => 2]);
+
+        $a0 = CardFactory::createOne(['lane' => $laneA, 'position' => 0]);
+        $a1 = CardFactory::createOne(['lane' => $laneA, 'position' => 1]);
+        $a2 = CardFactory::createOne(['lane' => $laneA, 'position' => 2]);
+        $b0 = CardFactory::createOne(['lane' => $laneB, 'position' => 0]);
+        $b1 = CardFactory::createOne(['lane' => $laneB, 'position' => 1]);
+
+        $laneAId = $laneA->getId();
+        $laneBId = $laneB->getId();
+        $a0Id = $a0->getId();
+        $a1Id = $a1->getId();
+        $a2Id = $a2->getId();
+        $b0Id = $b0->getId();
+        $b1Id = $b1->getId();
+
+        $this->mover()->move($a1->_real(), $laneB->_real(), 1);
+
+        // Discard stale in-memory positions: the move ran DQL bulk updates.
+        $this->em()->clear();
+
+        // Source lane is compacted back to a dense (0, 1) sequence.
+        $this->assertCardAt($a0Id, $laneAId, 0);
+        $this->assertCardAt($a2Id, $laneAId, 1);
+
+        // Moved card lands at index 1; the former B[1] is pushed down to 2.
+        $this->assertCardAt($b0Id, $laneBId, 0);
+        $this->assertCardAt($a1Id, $laneBId, 1);
+        $this->assertCardAt($b1Id, $laneBId, 2);
+    }
+
+    public function testMoveDownWithinLaneShiftsIntermediateCardsUp(): void
+    {
+        $board = BoardFactory::createOne();
+        $lane = LaneFactory::createOne(['board' => $board, 'position' => 1]);
+
+        $first = CardFactory::createOne(['lane' => $lane, 'position' => 0]);
+        $second = CardFactory::createOne(['lane' => $lane, 'position' => 1]);
+        $third = CardFactory::createOne(['lane' => $lane, 'position' => 2]);
+
+        $laneId = $lane->getId();
+        $firstId = $first->getId();
+        $secondId = $second->getId();
+        $thirdId = $third->getId();
+
+        $this->mover()->move($first->_real(), $lane->_real(), 2);
+
+        $this->em()->clear();
+
+        // Former positions 1 and 2 slide up to 0 and 1; the moved card takes 2.
+        $this->assertCardAt($secondId, $laneId, 0);
+        $this->assertCardAt($thirdId, $laneId, 1);
+        $this->assertCardAt($firstId, $laneId, 2);
+    }
+
+    public function testMoveUpWithinLaneShiftsIntermediateCardsDown(): void
+    {
+        $board = BoardFactory::createOne();
+        $lane = LaneFactory::createOne(['board' => $board, 'position' => 1]);
+
+        $first = CardFactory::createOne(['lane' => $lane, 'position' => 0]);
+        $second = CardFactory::createOne(['lane' => $lane, 'position' => 1]);
+        $third = CardFactory::createOne(['lane' => $lane, 'position' => 2]);
+
+        $laneId = $lane->getId();
+        $firstId = $first->getId();
+        $secondId = $second->getId();
+        $thirdId = $third->getId();
+
+        $this->mover()->move($third->_real(), $lane->_real(), 0);
+
+        $this->em()->clear();
+
+        // The moved card takes 0; former positions 0 and 1 slide down to 1 and 2.
+        $this->assertCardAt($thirdId, $laneId, 0);
+        $this->assertCardAt($firstId, $laneId, 1);
+        $this->assertCardAt($secondId, $laneId, 2);
+    }
+
+    public function testMoveToSameIndexKeepsAllPositionsUnchanged(): void
+    {
+        $board = BoardFactory::createOne();
+        $lane = LaneFactory::createOne(['board' => $board, 'position' => 1]);
+
+        $first = CardFactory::createOne(['lane' => $lane, 'position' => 0]);
+        $second = CardFactory::createOne(['lane' => $lane, 'position' => 1]);
+        $third = CardFactory::createOne(['lane' => $lane, 'position' => 2]);
+
+        $laneId = $lane->getId();
+        $firstId = $first->getId();
+        $secondId = $second->getId();
+        $thirdId = $third->getId();
+
+        $this->mover()->move($second->_real(), $lane->_real(), 1);
+
+        $this->em()->clear();
+
+        $this->assertCardAt($firstId, $laneId, 0);
+        $this->assertCardAt($secondId, $laneId, 1);
+        $this->assertCardAt($thirdId, $laneId, 2);
+    }
+
+    private function mover(): CardMover
+    {
+        return static::getContainer()->get(CardMover::class);
+    }
+
+    private function em(): EntityManagerInterface
+    {
+        return static::getContainer()->get(EntityManagerInterface::class);
+    }
+
+    /**
+     * Asserts a card's lane and position as stored in the database.
+     * EntityManager::clear() must have been called after the move so the
+     * card is re-hydrated from the database instead of the identity map.
+     */
+    private function assertCardAt(int $cardId, int $expectedLaneId, int $expectedPosition): void
+    {
+        $card = $this->em()->find(Card::class, $cardId);
+
+        $this->assertNotNull($card, sprintf('Card %d should exist.', $cardId));
+        $this->assertSame($expectedLaneId, $card->getLane()->getId());
+        $this->assertSame($expectedPosition, $card->getPosition());
+    }
+}

--- a/tests/Unit/Service/Board/BoardInvitationServiceTest.php
+++ b/tests/Unit/Service/Board/BoardInvitationServiceTest.php
@@ -1,0 +1,413 @@
+<?php
+
+namespace App\Tests\Unit\Service\Board;
+
+use App\Entity\Account;
+use App\Entity\Board;
+use App\Entity\BoardInvitation;
+use App\Repository\AccountRepository;
+use App\Repository\BoardInvitationRepository;
+use App\Service\Board\BoardInvitationService;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+
+#[CoversClass(BoardInvitationService::class)]
+final class BoardInvitationServiceTest extends TestCase
+{
+    private const ACCEPT_URL = 'https://taskio.test/invitations/accept';
+
+    // --- canInvite ---
+
+    public function testCanInviteReturnsFalseWhenPendingInvitationExists(): void
+    {
+        $board = $this->createBoard();
+
+        $invitationRepository = $this->createMock(BoardInvitationRepository::class);
+        $invitationRepository->expects($this->once())
+            ->method('findPendingByEmailAndBoard')
+            ->with('invitee@example.com', $board)
+            ->willReturn(new BoardInvitation());
+
+        // The account lookup must be short-circuited by the pending invitation.
+        $accountRepository = $this->createMock(AccountRepository::class);
+        $accountRepository->expects($this->never())->method('findOneBy');
+
+        $service = $this->createService(
+            accountRepository: $accountRepository,
+            invitationRepository: $invitationRepository,
+        );
+
+        $this->assertFalse($service->canInvite('invitee@example.com', $board));
+    }
+
+    public function testCanInviteReturnsFalseWhenAccountIsBoardOwner(): void
+    {
+        $owner = $this->createAccount('owner@example.com');
+        $board = $this->createBoard()->setOwner($owner);
+
+        $invitationRepository = $this->createMock(BoardInvitationRepository::class);
+        $invitationRepository->method('findPendingByEmailAndBoard')->willReturn(null);
+
+        $accountRepository = $this->createMock(AccountRepository::class);
+        $accountRepository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['email' => 'owner@example.com'])
+            ->willReturn($owner);
+
+        $service = $this->createService(
+            accountRepository: $accountRepository,
+            invitationRepository: $invitationRepository,
+        );
+
+        $this->assertFalse($service->canInvite('owner@example.com', $board));
+    }
+
+    public function testCanInviteReturnsFalseWhenAccountIsAlreadyCollaborator(): void
+    {
+        $member = $this->createAccount('member@example.com');
+        $board = $this->createBoard();
+        $board->addAccount($member);
+
+        $invitationRepository = $this->createMock(BoardInvitationRepository::class);
+        $invitationRepository->method('findPendingByEmailAndBoard')->willReturn(null);
+
+        $accountRepository = $this->createMock(AccountRepository::class);
+        $accountRepository->method('findOneBy')->willReturn($member);
+
+        $service = $this->createService(
+            accountRepository: $accountRepository,
+            invitationRepository: $invitationRepository,
+        );
+
+        $this->assertFalse($service->canInvite('member@example.com', $board));
+    }
+
+    public function testCanInviteReturnsTrueWhenAccountIsNeitherOwnerNorCollaborator(): void
+    {
+        $stranger = $this->createAccount('stranger@example.com');
+        $board = $this->createBoard()->setOwner($this->createAccount('owner@example.com'));
+
+        $invitationRepository = $this->createMock(BoardInvitationRepository::class);
+        $invitationRepository->method('findPendingByEmailAndBoard')->willReturn(null);
+
+        // The account exists but is not related to the board in any way.
+        $accountRepository = $this->createMock(AccountRepository::class);
+        $accountRepository->method('findOneBy')->willReturn($stranger);
+
+        $service = $this->createService(
+            accountRepository: $accountRepository,
+            invitationRepository: $invitationRepository,
+        );
+
+        $this->assertTrue($service->canInvite('stranger@example.com', $board));
+    }
+
+    // --- createInvitation ---
+
+    public function testCreateInvitationPersistsAndReturnsConfiguredInvitation(): void
+    {
+        $board = $this->createBoard();
+        $inviter = $this->createAccount('john.doe@example.com');
+
+        $invitationRepository = $this->createMock(BoardInvitationRepository::class);
+        $invitationRepository->expects($this->once())
+            ->method('save')
+            ->with($this->isInstanceOf(BoardInvitation::class));
+
+        $service = $this->createService(invitationRepository: $invitationRepository);
+
+        $invitation = $service->createInvitation('invitee@example.com', $board, $inviter);
+
+        $this->assertSame($board, $invitation->getBoard());
+        $this->assertSame('invitee@example.com', $invitation->getEmail());
+        $this->assertSame($inviter, $invitation->getInvitedBy());
+        // Token and expiry are initialized by the entity constructor.
+        $this->assertNotEmpty($invitation->getToken());
+        $this->assertGreaterThan(new \DateTimeImmutable(), $invitation->getExpiresAt());
+    }
+
+    // --- acceptInvitation ---
+
+    public function testAcceptInvitationAddsAccountToBoardAndMarksAccepted(): void
+    {
+        $board = $this->createBoard();
+        $user = $this->createAccount('new.member@example.com');
+        $invitation = $this->createInvitationFor($board, 'new.member@example.com');
+
+        $invitationRepository = $this->createMock(BoardInvitationRepository::class);
+        $invitationRepository->expects($this->once())->method('save')->with($invitation);
+
+        $service = $this->createService(invitationRepository: $invitationRepository);
+
+        $service->acceptInvitation($invitation, $user);
+
+        $this->assertTrue($board->getAccounts()->contains($user));
+        $this->assertTrue($invitation->isAccepted());
+    }
+
+    public function testAcceptInvitationDoesNotAddAccountTwiceButStillMarksAccepted(): void
+    {
+        $board = $this->createBoard();
+        $user = $this->createAccount('already.member@example.com');
+        $board->addAccount($user);
+        $invitation = $this->createInvitationFor($board, 'already.member@example.com');
+
+        $invitationRepository = $this->createMock(BoardInvitationRepository::class);
+        $invitationRepository->expects($this->once())->method('save')->with($invitation);
+
+        $service = $this->createService(invitationRepository: $invitationRepository);
+
+        $service->acceptInvitation($invitation, $user);
+
+        $this->assertCount(1, $board->getAccounts());
+        $this->assertTrue($invitation->isAccepted());
+    }
+
+    // --- cancelInvitation / cancelInvitationById ---
+
+    public function testCancelInvitationDelegatesToRepositoryRemove(): void
+    {
+        $invitation = $this->createInvitationFor($this->createBoard(), 'invitee@example.com');
+
+        $invitationRepository = $this->createMock(BoardInvitationRepository::class);
+        $invitationRepository->expects($this->once())->method('remove')->with($invitation);
+
+        $service = $this->createService(invitationRepository: $invitationRepository);
+
+        $service->cancelInvitation($invitation);
+    }
+
+    public function testCancelInvitationByIdThrowsWhenInvitationIsUnknown(): void
+    {
+        $board = $this->createBoard();
+
+        $invitationRepository = $this->createMock(BoardInvitationRepository::class);
+        $invitationRepository->method('find')->with(999)->willReturn(null);
+        $invitationRepository->expects($this->never())->method('remove');
+
+        $service = $this->createService(invitationRepository: $invitationRepository);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid invitation');
+
+        $service->cancelInvitationById(999, $board);
+    }
+
+    public function testCancelInvitationByIdThrowsWhenInvitationBelongsToAnotherBoard(): void
+    {
+        $ownBoard = $this->createBoard();
+        $this->setEntityId($ownBoard, 1);
+
+        $otherBoard = $this->createBoard('Other board');
+        $this->setEntityId($otherBoard, 2);
+
+        $invitation = $this->createInvitationFor($otherBoard, 'invitee@example.com');
+
+        $invitationRepository = $this->createMock(BoardInvitationRepository::class);
+        $invitationRepository->method('find')->with(42)->willReturn($invitation);
+        $invitationRepository->expects($this->never())->method('remove');
+
+        $service = $this->createService(invitationRepository: $invitationRepository);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid invitation');
+
+        $service->cancelInvitationById(42, $ownBoard);
+    }
+
+    public function testCancelInvitationByIdRemovesInvitationOfTheSameBoard(): void
+    {
+        $board = $this->createBoard();
+        $this->setEntityId($board, 7);
+
+        $invitation = $this->createInvitationFor($board, 'invitee@example.com');
+
+        $invitationRepository = $this->createMock(BoardInvitationRepository::class);
+        $invitationRepository->method('find')->with(42)->willReturn($invitation);
+        $invitationRepository->expects($this->once())->method('remove')->with($invitation);
+
+        $service = $this->createService(invitationRepository: $invitationRepository);
+
+        $service->cancelInvitationById(42, $board);
+    }
+
+    // --- removeCollaborator ---
+
+    public function testRemoveCollaboratorDetachesAccountAndPersistsIt(): void
+    {
+        $board = $this->createBoard();
+        $collaborator = $this->createAccount('collab@example.com');
+        $board->addAccount($collaborator);
+
+        $accountRepository = $this->createMock(AccountRepository::class);
+        $accountRepository->expects($this->once())->method('save')->with($collaborator);
+
+        $service = $this->createService(accountRepository: $accountRepository);
+
+        $service->removeCollaborator($board, $collaborator);
+
+        $this->assertFalse($board->getAccounts()->contains($collaborator));
+        $this->assertFalse($collaborator->getBoards()->contains($board));
+    }
+
+    // --- processInvitation ---
+
+    public function testProcessInvitationDoesNothingWhenInvitationIsPending(): void
+    {
+        $board = $this->createBoard();
+        $inviter = $this->createAccount('john.doe@example.com');
+
+        $invitationRepository = $this->createMock(BoardInvitationRepository::class);
+        $invitationRepository->method('findPendingByEmailAndBoard')
+            ->willReturn(new BoardInvitation());
+        $invitationRepository->expects($this->never())->method('save');
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects($this->never())->method('send');
+
+        $service = $this->createService(
+            invitationRepository: $invitationRepository,
+            mailer: $mailer,
+        );
+
+        $service->processInvitation('invitee@example.com', $board, $inviter);
+    }
+
+    public function testProcessInvitationDoesNotPropagateMailerFailure(): void
+    {
+        $board = $this->createBoard();
+        $inviter = $this->createAccount('john.doe@example.com');
+
+        $invitationRepository = $this->createMock(BoardInvitationRepository::class);
+        $invitationRepository->method('findPendingByEmailAndBoard')->willReturn(null);
+        $invitationRepository->expects($this->once())
+            ->method('save')
+            ->with($this->isInstanceOf(BoardInvitation::class));
+
+        $accountRepository = $this->createMock(AccountRepository::class);
+        $accountRepository->method('findOneBy')->willReturn(null);
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects($this->once())
+            ->method('send')
+            ->willThrowException(new \RuntimeException('SMTP server unreachable'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('error');
+
+        $service = $this->createService(
+            accountRepository: $accountRepository,
+            invitationRepository: $invitationRepository,
+            mailer: $mailer,
+            logger: $logger,
+        );
+
+        // Must not throw: failures are swallowed to prevent email enumeration.
+        $service->processInvitation('invitee@example.com', $board, $inviter);
+
+        $this->addToAssertionCount(1); // Reaching this line means nothing propagated.
+    }
+
+    // --- sendInvitationEmail ---
+
+    public function testSendInvitationEmailReturnsTrueOnSuccess(): void
+    {
+        $invitation = $this->createInvitationFor($this->createBoard(), 'invitee@example.com');
+
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->expects($this->once())
+            ->method('generate')
+            ->with(
+                'app_board_accept_invitation',
+                ['token' => $invitation->getToken()],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            )
+            ->willReturn(self::ACCEPT_URL);
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects($this->once())
+            ->method('send')
+            ->with($this->callback(
+                static fn (Email $email): bool => $email->getTo()[0]->getAddress() === 'invitee@example.com'
+                    && str_contains((string) $email->getHtmlBody(), self::ACCEPT_URL)
+            ));
+
+        $service = $this->createService(mailer: $mailer, urlGenerator: $urlGenerator);
+
+        $this->assertTrue($service->sendInvitationEmail($invitation));
+    }
+
+    public function testSendInvitationEmailReturnsFalseWhenMailerThrows(): void
+    {
+        $invitation = $this->createInvitationFor($this->createBoard(), 'invitee@example.com');
+
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer->expects($this->once())
+            ->method('send')
+            ->willThrowException(new \RuntimeException('SMTP server unreachable'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects($this->once())->method('error');
+
+        $service = $this->createService(mailer: $mailer, logger: $logger);
+
+        $this->assertFalse($service->sendInvitationEmail($invitation));
+    }
+
+    // --- Helpers ---
+
+    private function createService(
+        ?AccountRepository $accountRepository = null,
+        ?BoardInvitationRepository $invitationRepository = null,
+        ?MailerInterface $mailer = null,
+        ?UrlGeneratorInterface $urlGenerator = null,
+        ?LoggerInterface $logger = null,
+    ): BoardInvitationService {
+        return new BoardInvitationService(
+            $accountRepository ?? $this->createMock(AccountRepository::class),
+            $invitationRepository ?? $this->createMock(BoardInvitationRepository::class),
+            $mailer ?? $this->createMock(MailerInterface::class),
+            $urlGenerator ?? $this->createMock(UrlGeneratorInterface::class),
+            $logger ?? $this->createMock(LoggerInterface::class),
+        );
+    }
+
+    private function createBoard(string $title = 'Project board'): Board
+    {
+        return (new Board())->setTitle($title);
+    }
+
+    private function createAccount(string $email): Account
+    {
+        return (new Account())
+            ->setEmail($email)
+            ->setName('John')
+            ->setLastname('Doe');
+    }
+
+    /**
+     * Build a fully wired invitation (board, email, inviter) so that the
+     * email content can be rendered without null values.
+     */
+    private function createInvitationFor(Board $board, string $email): BoardInvitation
+    {
+        return (new BoardInvitation())
+            ->setBoard($board)
+            ->setEmail($email)
+            ->setInvitedBy($this->createAccount('inviter@example.com'));
+    }
+
+    /**
+     * Entities never expose an id setter; force one through reflection to
+     * exercise the board ownership check of cancelInvitationById().
+     */
+    private function setEntityId(object $entity, int $id): void
+    {
+        $property = new \ReflectionProperty($entity, 'id');
+        $property->setValue($entity, $id);
+    }
+}


### PR DESCRIPTION
## Summary

Fills the test coverage gaps left by the DTO → Service → Repository refactor: **+60 tests (131 → 191, 543 assertions)**, all green locally.

| Area | File | What it locks down |
|---|---|---|
| Unit | `tests/Unit/Service/Board/BoardInvitationServiceTest.php` | 16 tests: `canInvite`, create/accept/cancel invitation, `removeCollaborator`, enumeration-safe `processInvitation`, mailer failure path |
| Integration | `tests/Integration/Service/Board/CardMoverTest.php` | The trickiest code in the app against a real database: cross-lane move (source compaction + target shifting), both intra-lane directions, same-index no-op |
| Integration | `tests/Integration/Repository/CardRepositoryTest.php` | The DQL bulk helpers: `compactAfterRemoval`, `makeRoomAt`, `shiftWithinLane` (both directions), `findMaxPositionInLane`, `findIdsByLaneOrdered` |
| Integration | `tests/Integration/Repository/BoardRepositoryTest.php` | `findVisibleForUser` (distinct semantics), `isBoardMember`, `findByAccount`, `findWithLanesAndCards` ordering, `qbForAdmin` search |
| Integration | `tests/Integration/Repository/BoardInvitationRepositoryTest.php` | `findPendingByEmailAndBoard` criteria: pending vs accepted vs expired, email normalization |
| Functional | `tests/Functional/Controller/PublicPagesTest.php` | Smoke tests for every public page; `/price` stays 404 |
| Functional | `tests/Functional/Controller/BoardInvitationFlowTest.php` | Full invitation flow over HTTP: invite, duplicate dedup, accept by token, unknown token, cancel, remove collaborator, 403 for non-owners |

The previously empty `integration` PHPUnit suite now has real content.

## Notes

- Integration tests clear the EntityManager after DQL bulk updates (they bypass the identity map) before asserting positions.
- The invite rate limiter needs no test override: it is keyed by user identifier and every test uses a unique faker email.
- **Merge order**: merge #31 (CI) first — this branch does not contain the workflow file, so CI will run here once `main` has it (re-trigger with a rebase/update of this branch).
